### PR TITLE
Support for Long article IDs

### DIFF
--- a/src/main/java/org/pentaho/di/trans/steps/zendesk/ZendeskInputHCArticle.java
+++ b/src/main/java/org/pentaho/di/trans/steps/zendesk/ZendeskInputHCArticle.java
@@ -161,14 +161,16 @@ public class ZendeskInputHCArticle extends ZendeskInput {
       Long articleId = getInputRowMeta().getValueMeta( data.incomingIndex ).getInteger( row[data.incomingIndex] );
       Article article = null;
       try {
-        article = data.conn.getArticle( articleId.intValue() );
+        article = data.conn.getArticle( articleId );
       } catch ( ZendeskResponseException zre ) {
         logError( BaseMessages.getString( PKG, "ZendeskInput.Error.Generic", zre ) );
         setErrors( 1L );
         setOutputDone();
         return false;
       }
-      if ( article != null ) {
+      if ( article == null ) {
+        logDebug( "Article " + articleId + " not found." );
+      } else {
         outputArticleRow( article );
         Iterable<Translation> translations = null;
         if ( meta.getTranslationStepMeta() != null ) {


### PR DESCRIPTION
Previous version of the Zendesk Java Client did not support Long values for Article IDs.  Updating steps to use Long as we're already using a newer Zendesk Java Client that supports Long values.